### PR TITLE
Set up Python 3.12 dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "alefragnani.numbered-bookmarks",
+                "bierner.markdown-preview-github-styles",
+                "eamodio.gitlens",
+                "GitHub.vscode-github-actions",
+                "GitHub.vscode-pull-request-github",
+                "mhutchie.git-graph",
+                "ms-python.python",
+                "ms-toolsai.jupyter",
+                "MS-vsliveshare.vsliveshare",
+                "stkb.rewrap",
+                "tamasfe.even-better-toml"
+            ],
+            "settings": {
+                "gitlens.showWelcomeOnInstall": false,
+                "gitlens.showWhatsNewAfterUpgrades": false
+            }
+        }
+    },
+    "onCreateCommand": [".devcontainer/onCreate"]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,10 @@
                 "files.trimFinalNewlines": true,
                 "files.trimTrailingWhitespace": true,
                 "gitlens.showWelcomeOnInstall": false,
-                "gitlens.showWhatsNewAfterUpgrades": false
+                "gitlens.showWhatsNewAfterUpgrades": false,
+                "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+                "python.terminal.activateEnvInCurrentTerminal": true,
+                "python.terminal.activateEnvironment": true
             }
         }
     },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,6 +16,10 @@
                 "tamasfe.even-better-toml"
             ],
             "settings": {
+                "files.eol": "\n",
+                "files.insertFinalNewline": true,
+                "files.trimFinalNewlines": true,
+                "files.trimTrailingWhitespace": true,
                 "gitlens.showWelcomeOnInstall": false,
                 "gitlens.showWhatsNewAfterUpgrades": false
             }

--- a/.devcontainer/git_prompt_activate.bash
+++ b/.devcontainer/git_prompt_activate.bash
@@ -1,0 +1,34 @@
+# This file, when sourced in ~/.bashrc, puts formatted __git_ps1 in $PS1.
+# Based on: https://github.com/EliahKagan/git_prompt_activate
+
+# shellcheck shell=bash
+# shellcheck disable=SC1091  # Not checking /usr/lib/git-core/git-sh-prompt.
+# shellcheck disable=SC2016  # PS1 will contain $ syntax for later expansion.
+# shellcheck disable=SC2034  # GIT_PS1_ vars will be assigned for later use.
+
+if test "$(git config devcontainers-theme.hide-status)" = 1 ||
+   test "$(git config codespaces-theme.hide-status)" = 1
+then
+    . /usr/lib/git-core/git-sh-prompt
+
+    git_prompt_part='$(__git_ps1 "(%s)")'
+
+    case "$TERM" in
+    xterm-color|*-256color)  # See color_prompt in .bashrc.
+        git_prompt_part='\[\033[36m\]'"$git_prompt_part"'\[\033[0m\]' ;;
+    esac
+
+    case "$PS1" in
+    *'\$ ')
+        PS1="${PS1/%\\$ /$git_prompt_part\\$ }" ;;
+    *)
+        PS1="${PS1/%$ /$git_prompt_part\\$ }" ;;
+    esac
+
+    unset git_prompt_part
+
+    GIT_PS1_SHOWDIRTYSTATE=1
+    GIT_PS1_SHOWSTASHSTATE=1
+    GIT_PS1_SHOWUNTRACKEDFILES=1
+    GIT_PS1_SHOWUPSTREAM=1
+fi

--- a/.devcontainer/onCreate
+++ b/.devcontainer/onCreate
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 
@@ -8,3 +8,9 @@ ln -s -- "$(realpath .devcontainer/git_prompt_activate.bash)" \
 printf '\n%s\n' '. ~/.git_prompt_activate.bash' >>~/.bashrc
 git config --global color.diff.new blue
 git config --global devcontainers-theme.hide-status 1
+
+# Set up the project virtual environment.
+python -m venv .venv
+. .venv/bin/activate
+python -m pip install -U pip wheel
+pip install -r requirements.txt

--- a/.devcontainer/onCreate
+++ b/.devcontainer/onCreate
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eu
+
+# Customize git configuration for shell prompt and terminal colors.
+ln -s -- "$(realpath .devcontainer/git_prompt_activate.bash)" \
+    ~/.git_prompt_activate.bash
+printf '\n%s\n' '. ~/.git_prompt_activate.bash' >>~/.bashrc
+git config --global color.diff.new blue
+git config --global devcontainers-theme.hide-status 1

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# It is convenient, where feasible, for text files to have LF (Unix-style) line
+# endings. This especially helps when cloning on Windows into a dev container.
+* text=auto eol=lf
+
+# Shell scripts *need* LF line endings, even if we change the main rule above.
+# (Listing them also covers the case where git fails to detect them as text.)
+/.devcontainer/git_prompt_activate.bash text eol=lf
+/.devcontainer/onCreate text eol=lf


### PR DESCRIPTION
This adds a [dev container](https://code.visualstudio.com/docs/devcontainers/create-dev-container) configuration for a Python 3.12 development environment. The main benefit of this is that [codespaces](https://github.com/features/codespaces) will use it, though it can also be used as a local dev container on a machine with VS Code and Docker.

Main customizations:

- Debian image for Python 3.12 development (vs. the universal image, which has Python 3.10)
- Various useful VS Code extensions for Python development and working with Git
- Custom git prompt
- Custom git diff colors that are easy to read in both light and dark modes
- Create the project virtual environment and install dependencies on container creation
- Have VS Code automatically activate the virtual environment when using the dev container
- Use LF line endings on all systems (helps edges cases with local dev containers)
- Strip trailing whitespace and fix end-of-file newlines on save

This does carry one disadvantage: startup time is a bit longer. But this is not severe, and I think it's worthwhile.

For this project, it may be that the most important benefit of these changes is using 3.12, since that allows the newest Python language and library features and behavior to be showcased, practiced, and experimented with.