### PR TITLE
Add more decorators exercises and improve existing ones

### DIFF
--- a/caching.py
+++ b/caching.py
@@ -29,6 +29,9 @@ def memoize(func):
     >>> hello('Bob')
     Hello, Bob!
     >>> hello('Alice')  # Doesn't print.
+
+    >>> fib.__name__, fibonacci.__name__, hello.__name__
+    ('fib', 'fibonacci', 'hello')
     >>>
     """
     # FIXME: Implement this.

--- a/caching.py
+++ b/caching.py
@@ -1,31 +1,44 @@
 """Caching decorators."""
 
 import functools
+import math
 
 
-def memoize(func):
+def memoize_unary(func):
     """
     Decorator to memoize a unary function.
 
     This caches the results of function calls, using hashing.
 
     We retain memory of previous results even across separate top-level calls,
-    for simplicity and because this behavior is sometimes useful (though it
-    also has major disadvantages, such as not being thread-safe).
+    for simplicity and because this behavior is sometimes useful. It also has
+    major disadvantages, such as not being thread-safe. But it's more versatile
+    than it may seem, because one can define an undecorated top-level function
+    that defines a decorated local helper function. (The example of this in the
+    doctests uses variables from the enclosing scope, but the technique is also
+    sometimes useful just to eliminate global state and make concurrency safe.)
 
-    >>> def fib(n):
-    ...     return n if n < 2 else fib(n - 2) + fib(n - 1)
-    >>> fib = memoize(fib)
-    >>> fib(100)
-    354224848179261915075
-
-    >>> @memoize
+    >>> @memoize_unary
     ... def fibonacci(n):
     ...     return n if n < 2 else fibonacci(n - 2) + fibonacci(n - 1)
     >>> fibonacci(100)
     354224848179261915075
 
-    >>> @memoize
+    >>> def fib(n, *, a, b):
+    ...     @memoize_unary
+    ...     def helper(n):
+    ...         if n == 0:
+    ...             return a
+    ...         if n == 1:
+    ...             return b
+    ...         return helper(n - 2) + helper(n - 1)
+    ...     return helper(n)
+    >>> fib(100, a=0, b=1)
+    354224848179261915075
+    >>> fib(100, a=2, b=1)  # Compute a Lucas number.
+    792070839848372253127
+
+    >>> @memoize_unary
     ... def hello(name):
     ...     print(f'Hello, {name}!')
     >>> hello('Alice')
@@ -38,30 +51,34 @@ def memoize(func):
     ('fib', 'fibonacci', 'hello')
     >>>
     """
-    return memoize_by(lambda arg: arg)(func)
+    return memoize_unary_by(lambda arg: arg)(func)
 
 
-def memoize_by(key):
+def memoize_unary_by(key):
     """
     Parameterized decorator to memoize a unary function with a key selector.
 
-    This is like memoize, but the key selector function, key, is used to select
-    a value representing the information used for hash-based comparison.
+    This is like memoize_unary, but the key selector function, key, is used to
+    select a value representing the information used for hash-based comparison.
 
     The parameter for the key selector function is somewhat confusingly named
     "key". This is for consistency with the min, max, sorted, and list.sort
     functions accepting key selector functions as keyword-only "key" arguments.
 
+    Note that the circumstance under which it is safe to use id as a key
+    selector are limited by how ids are reused: they are only guaranteed unique
+    across objects with overlapping lifetimes.
+
     >>> import math
     >>> from decorators import peek_unary
 
-    >>> @memoize_by(lambda x: x)
+    >>> @memoize_unary_by(lambda x: x)
     ... def fibonacci(n):
     ...     return n if n < 2 else fibonacci(n - 2) + fibonacci(n - 1)
     >>> fibonacci(100)
     354224848179261915075
 
-    >>> @memoize_by(str.casefold)
+    >>> @memoize_unary_by(str.casefold)
     ... def hello(name):
     ...     return f'Hello, {name}!'
     >>> hello('Alice')
@@ -71,7 +88,7 @@ def memoize_by(key):
     >>> hello('alice')
     'Hello, Alice!'
 
-    >>> @memoize_by(tuple)
+    >>> @memoize_unary_by(tuple)
     ... @peek_unary
     ... def pythagorean(values):
     ...     return math.hypot(*values)
@@ -87,7 +104,7 @@ def memoize_by(key):
     5.385164807134504
 
     >>> rows = ([], [], [], [], [], [], [], [])  # Imagine this were bigger.
-    >>> @memoize_by(id)
+    >>> @memoize_unary_by(id)
     ... @peek_unary
     ... def row_index(row):
     ...     for index, current_row in enumerate(rows):
@@ -114,6 +131,284 @@ def memoize_by(key):
                 cache[computed_key] = result
                 return result
 
+        return wrapper
+
+    return decorator
+
+
+def memoize(func):
+    """
+    Decorator to memoize a function.
+
+    This caches results of function calls, using hashing. Subsequent calls with
+    equal corresponding arguments in the same order return a cached result.
+
+    >>> import functools, itertools, random
+
+    >>> @memoize
+    ... def fibonacci(n):
+    ...     return n if n < 2 else fibonacci(n - 2) + fibonacci(n - 1)
+    >>> fibonacci(100)
+    354224848179261915075
+
+    >>> def knapsack(vals, weights, capacity):  # 0-1 knapsack problem.
+    ...     @memoize
+    ...     def solve_from(i, c):
+    ...         if i == len(vals):
+    ...             return 0
+    ...         ret = solve_from(i + 1, c)
+    ...         if weights[i] <= c:
+    ...             ret = max(ret, vals[i] + solve_from(i + 1, c - weights[i]))
+    ...         return ret
+    ...     return solve_from(0, capacity)
+    >>> knapsack([410, 23, 8, 46, 19, 1, 16], [200, 11, 6, 29, 12, 1, 13], 250)
+    488
+    >>> r = functools.partial(random.Random(13932671453525407).randint, 1, 100)
+    >>> knapsack([r() for _ in range(100)], [r() for _ in range(100)], 2500)
+    4009
+
+    >>> counter = itertools.count()
+    >>> @memoize
+    ... def label(*args, **kwargs):
+    ...     return next(counter)
+    >>> label(14, 'foo', 'walleye', x=frozenset({2, 3}), y=(42,))
+    0
+    >>> label()
+    1
+    >>> label(14, 'foo', 'walleye', x=frozenset({2, 3}), y='(42,)')
+    2
+    >>> label(14.0, 'foo', 'walleye', x=frozenset({3, 2}), y=(42 + 0j,))
+    0
+    >>> label(14, 'foo', 'walleye', y=(42,), x=frozenset({2, 3}))
+    3
+    """
+    sentinel = object()
+    cache = {}
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        computed_key = (*args, sentinel, *kwargs.items())
+        try:
+            return cache[computed_key]
+        except KeyError:
+            result = func(*args, **kwargs)
+            cache[computed_key] = result
+            return result
+
+    return wrapper
+
+
+def memoize_by(key):
+    """
+    Parameterized decorator to memoize a function with a key selector.
+
+    This is like memoize, but the key selector function, key, is used to select
+    a value representing the information used for hash-based comparison, when
+    called in the same way as the decorated function was itself called.
+
+    >>> @memoize_by(str.casefold)
+    ... def hello(name):
+    ...     return f'Hello, {name}!'
+    >>> hello('Alice')
+    'Hello, Alice!'
+    >>> hello('bob')
+    'Hello, bob!'
+    >>> hello('alice')
+    'Hello, Alice!'
+
+    >>> @memoize_by(lambda seq, start, stop: (id(seq), start, stop))
+    ... def cached_range_sum(seq, start, stop):
+    ...     return sum(seq[start:stop])
+    >>> a = [4, 17, 9, 8, -3, 1]
+    >>> cached_range_sum(a, 2, 5)
+    14
+    >>> a[2] += 10
+    >>> cached_range_sum(a, 1, 5)
+    41
+    >>> cached_range_sum(a, 2, 5)
+    14
+    >>> b = a[:]  # Must assign this to a variable, so its id can't be reused!
+    >>> cached_range_sum(b, 2, 5)
+    24
+    >>> a.clear()
+    >>> c = a[:]
+    >>> cached_range_sum(c, 2, 5)
+    0
+    >>> cached_range_sum(a, stop=5, start=2)
+    14
+    """
+    def decorator(func):
+        cache = {}
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            computed_key = key(*args, **kwargs)
+            try:
+                return cache[computed_key]
+            except KeyError:
+                result = func(*args, **kwargs)
+                cache[computed_key] = result
+                return result
+
+        return wrapper
+
+    return decorator
+
+
+def lru(max_size):
+    R"""
+    Parameterized decorator implementing a least recently used (LRU) cache.
+
+    Decorating a function with the decorator returned by calling lru places an
+    LRU cache in front of the function, so the max_size most recent calls are
+    cached. When a cache miss occurs and the computation succeeds, the least
+    recently used mapping from arguments to their result is evicted from the
+    cache, and the newly computed mapping replaces it.
+
+    >>> lru(0)
+    Traceback (most recent call last):
+      ...
+    ValueError: max_size must be strictly positive (got 0)
+    >>> lru(5.0)
+    Traceback (most recent call last):
+      ...
+    TypeError: max_size must be an int or infinity (got 'float')
+    >>> lru(0.0)
+    Traceback (most recent call last):
+      ...
+    TypeError: max_size must be an int or infinity (got 'float')
+
+    >>> @lru(5)
+    ... def square(n):
+    ...     '''Square a number, pretending this is very resource-intensive.'''
+    ...     print(f'Pretending to call the expensive SQUARING API for {n=}.')
+    ...     return n**2
+    >>> square(3)
+    Pretending to call the expensive SQUARING API for n=3.
+    9
+    >>> square(4)
+    Pretending to call the expensive SQUARING API for n=4.
+    16
+    >>> square(3.0)
+    9
+    >>> square(5)
+    Pretending to call the expensive SQUARING API for n=5.
+    25
+    >>> square(-5)
+    Pretending to call the expensive SQUARING API for n=-5.
+    25
+    >>> square(-10)
+    Pretending to call the expensive SQUARING API for n=-10.
+    100
+    >>> try:
+    ...     square('a parrot')
+    ... except TypeError as error:
+    ...     print(error)
+    Pretending to call the expensive SQUARING API for n='a parrot'.
+    unsupported operand type(s) for ** or pow(): 'str' and 'int'
+    >>> square(4)
+    16
+    >>> square(7)
+    Pretending to call the expensive SQUARING API for n=7.
+    49
+    >>> square(5)
+    25
+    >>> square(-10)
+    100
+    >>> square(3.0)
+    Pretending to call the expensive SQUARING API for n=3.0.
+    9.0
+
+    >>> import math
+    >>> a = []
+    >>> f = lru(math.inf)(a.append)
+    >>> for i in range(10_000): f(i)  # Should work with larger numbers too.
+    >>> f(23)
+    >>> a == list(range(10_000))
+    True
+
+    >>> @lru(True)  # Bad way to say @lru(1). Works since bool subclasses int.
+    ... def idempotent_printf(format, *args, end=''):
+    ...     text = format % args
+    ...     print(text, end=end)
+    ...     return len(text) + len(end)
+    >>> idempotent_printf('%r is %d letters.', 'parrot', len('parrot'), end='\n')
+    'parrot' is 6 letters.
+    23
+    >>> idempotent_printf('%r is %d letters.', 'parrot', len('parrot'), end='\n')
+    23
+    >>> idempotent_printf('%r is %d letters.\n', 'parrot', len('parrot'))
+    'parrot' is 6 letters.
+    23
+    >>> idempotent_printf('%r has %d letters.\n', 'parrot', len('parrot'))
+    'parrot' has 6 letters.
+    24
+    >>> idempotent_printf('%r has %d letters.\n', 'parrot', 6.0)
+    24
+    >>> idempotent_printf('%r has %d letters.\n', 'parrot', 6.99)
+    'parrot' has 6 letters.
+    24
+    >>> idempotent_printf('%r has %d letters.\n', 'parrot', 6.0)  # max_size==1
+    'parrot' has 6 letters.
+    24
+
+    >>> square(4)
+    16
+    >>> square(3)
+    9.0
+    >>> square(6)
+    Pretending to call the expensive SQUARING API for n=6.
+    36
+    >>> square(7)
+    Pretending to call the expensive SQUARING API for n=7.
+    49
+    >>> square.clear()
+    >>> square(7)
+    Pretending to call the expensive SQUARING API for n=7.
+    49
+    >>> idempotent_printf('%r has %d letters.\n', 'parrot', 6.0)
+    24
+    >>> square(7)
+    49
+
+    >>> set(dir(square.__wrapped__)) == set(dir(lambda: None))
+    True
+    >>> sorted(set(dir(square)) - set(dir(square.__wrapped__)))
+    ['__wrapped__', 'clear']
+    >>> square.__name__, square.__doc__
+    ('square', 'Square a number, pretending this is very resource-intensive.')
+    >>> square.clear.__name__, square.clear.__doc__
+    ('clear', "Clear the wrapped function's LRU cache.")
+    """
+    if max_size != math.inf:
+        if not isinstance(max_size, int):
+            raise TypeError('max_size must be an int or infinity (got %r)'
+                            % type(max_size).__name__)
+        if max_size <= 0:
+            raise ValueError('max_size must be strictly positive (got %r)'
+                             % max_size)
+
+    def decorator(func):
+        sentinel = object()
+        cache = {}
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            computed_key = (*args, sentinel, *kwargs.items())
+            try:
+                result = cache.pop(computed_key)
+            except KeyError:
+                result = func(*args, **kwargs)
+                if len(cache) == max_size:
+                    cache.pop(next(iter(cache)))
+            cache[computed_key] = result
+            return result
+
+        def clear():
+            """Clear the wrapped function's LRU cache."""
+            cache.clear()
+
+        wrapper.clear = clear
         return wrapper
 
     return decorator

--- a/caching.py
+++ b/caching.py
@@ -1,9 +1,13 @@
 """Caching decorators."""
 
+import functools
+
 
 def memoize(func):
     """
-    Decorator to memoize a unary function, using hashing.
+    Decorator to memoize a unary function.
+
+    This caches the results of function calls, using hashing.
 
     We retain memory of previous results even across separate top-level calls,
     for simplicity and because this behavior is sometimes useful (though it
@@ -34,4 +38,82 @@ def memoize(func):
     ('fib', 'fibonacci', 'hello')
     >>>
     """
-    # FIXME: Implement this.
+    return memoize_by(lambda arg: arg)(func)
+
+
+def memoize_by(key):
+    """
+    Parameterized decorator to memoize a unary function with a key selector.
+
+    This is like memoize, but the key selector function, key, is used to select
+    a value representing the information used for hash-based comparison.
+
+    The parameter for the key selector function is somewhat confusingly named
+    "key". This is for consistency with the min, max, sorted, and list.sort
+    functions accepting key selector functions as keyword-only "key" arguments.
+
+    >>> import math
+    >>> from decorators import peek_unary
+
+    >>> @memoize_by(lambda x: x)
+    ... def fibonacci(n):
+    ...     return n if n < 2 else fibonacci(n - 2) + fibonacci(n - 1)
+    >>> fibonacci(100)
+    354224848179261915075
+
+    >>> @memoize_by(str.casefold)
+    ... def hello(name):
+    ...     return f'Hello, {name}!'
+    >>> hello('Alice')
+    'Hello, Alice!'
+    >>> hello('bob')
+    'Hello, bob!'
+    >>> hello('alice')
+    'Hello, Alice!'
+
+    >>> @memoize_by(tuple)
+    ... @peek_unary
+    ... def pythagorean(values):
+    ...     return math.hypot(*values)
+    >>> pythagorean([2, 3, 4])
+    pythagorean([2, 3, 4])
+    pythagorean([2, 3, 4]) -> 5.385164807134504
+    5.385164807134504
+    >>> pythagorean([2, 3, 4])
+    5.385164807134504
+    >>> pythagorean([2, 4, 3])
+    pythagorean([2, 4, 3])
+    pythagorean([2, 4, 3]) -> 5.385164807134504
+    5.385164807134504
+
+    >>> rows = ([], [], [], [], [], [], [], [])  # Imagine this were bigger.
+    >>> @memoize_by(id)
+    ... @peek_unary
+    ... def row_index(row):
+    ...     for index, current_row in enumerate(rows):
+    ...         if current_row is row:
+    ...             return index
+    ...     raise ValueError(f'row with id {id(row)} not found')
+    >>> row_index(rows[3])
+    row_index([])
+    row_index([]) -> 3
+    3
+    >>> row_index(rows[3])
+    3
+    """
+    def decorator(func):
+        cache = {}
+
+        @functools.wraps(func)
+        def wrapper(arg):
+            computed_key = key(arg)
+            try:
+                return cache[computed_key]
+            except KeyError:
+                result = func(arg)
+                cache[computed_key] = result
+                return result
+
+        return wrapper
+
+    return decorator

--- a/caching.py
+++ b/caching.py
@@ -1,8 +1,5 @@
 """Caching decorators."""
 
-import functools
-import math
-
 
 def memoize_unary(func):
     """
@@ -51,7 +48,7 @@ def memoize_unary(func):
     ('fib', 'fibonacci', 'hello')
     >>>
     """
-    return memoize_unary_by(lambda arg: arg)(func)
+    # FIXME: Implement this.
 
 
 def memoize_unary_by(key):
@@ -118,22 +115,7 @@ def memoize_unary_by(key):
     >>> row_index(rows[3])
     3
     """
-    def decorator(func):
-        cache = {}
-
-        @functools.wraps(func)
-        def wrapper(arg):
-            computed_key = key(arg)
-            try:
-                return cache[computed_key]
-            except KeyError:
-                result = func(arg)
-                cache[computed_key] = result
-                return result
-
-        return wrapper
-
-    return decorator
+    # FIXME: Implement this.
 
 
 def memoize(func):
@@ -182,20 +164,7 @@ def memoize(func):
     >>> label(14, 'foo', 'walleye', y=(42,), x=frozenset({2, 3}))
     3
     """
-    sentinel = object()
-    cache = {}
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        computed_key = (*args, sentinel, *kwargs.items())
-        try:
-            return cache[computed_key]
-        except KeyError:
-            result = func(*args, **kwargs)
-            cache[computed_key] = result
-            return result
-
-    return wrapper
+    # FIXME: Implement this.
 
 
 def memoize_by(key):
@@ -237,22 +206,7 @@ def memoize_by(key):
     >>> cached_range_sum(a, stop=5, start=2)
     14
     """
-    def decorator(func):
-        cache = {}
-
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            computed_key = key(*args, **kwargs)
-            try:
-                return cache[computed_key]
-            except KeyError:
-                result = func(*args, **kwargs)
-                cache[computed_key] = result
-                return result
-
-        return wrapper
-
-    return decorator
+    # FIXME: Implement this.
 
 
 def lru(max_size):
@@ -380,35 +334,4 @@ def lru(max_size):
     >>> square.clear.__name__, square.clear.__doc__
     ('clear', "Clear the wrapped function's LRU cache.")
     """
-    if max_size != math.inf:
-        if not isinstance(max_size, int):
-            raise TypeError('max_size must be an int or infinity (got %r)'
-                            % type(max_size).__name__)
-        if max_size <= 0:
-            raise ValueError('max_size must be strictly positive (got %r)'
-                             % max_size)
-
-    def decorator(func):
-        sentinel = object()
-        cache = {}
-
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            computed_key = (*args, sentinel, *kwargs.items())
-            try:
-                result = cache.pop(computed_key)
-            except KeyError:
-                result = func(*args, **kwargs)
-                if len(cache) == max_size:
-                    cache.pop(next(iter(cache)))
-            cache[computed_key] = result
-            return result
-
-        def clear():
-            """Clear the wrapped function's LRU cache."""
-            cache.clear()
-
-        wrapper.clear = clear
-        return wrapper
-
-    return decorator
+    # FIXME: Implement this.

--- a/decorators.py
+++ b/decorators.py
@@ -1,10 +1,5 @@
 """Various decorators."""
 
-import functools
-from fractions import Fraction
-import math
-import time
-
 
 def call(func):
     """
@@ -17,8 +12,7 @@ def call(func):
     >>> hello()
     Hello, world!
     """
-    func()
-    return func
+    # FIXME: Implement this.
 
 
 def twice_unary(func):
@@ -60,12 +54,7 @@ def twice_unary(func):
     >>> square.__name__, cube.__name__
     ('square', 'cube')
     """
-    @functools.wraps(func)
-    def wrapper(arg):
-        func(arg)
-        return func(arg)
-
-    return wrapper
+    # FIXME: Implement this.
 
 
 def peek_unary(func):
@@ -120,15 +109,7 @@ def peek_unary(func):
     >>> a
     ['foo']
     """
-    @functools.wraps(func)
-    def wrapper(arg):
-        call_repr = f'{func.__name__}({arg!r})'
-        print(call_repr)
-        result = func(arg)
-        print(f'{call_repr} -> {result!r}')
-        return result
-
-    return wrapper
+    # FIXME: Implement this.
 
 
 def twice(func):
@@ -163,12 +144,7 @@ def twice(func):
     x=11, y=22
     x=11, y=22
     """
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        func(*args, **kwargs)
-        return func(*args, **kwargs)
-
-    return wrapper
+    # FIXME: Implement this.
 
 
 def repeat(count):
@@ -206,17 +182,7 @@ def repeat(count):
     >>> repeat(0)(lambda: 42)() is None
     True
     """
-    def decorator(func):
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            result = None
-            for _ in range(count):
-                result = func(*args, **kwargs)
-            return result
-
-        return wrapper
-
-    return decorator
+    # FIXME: Implement this.
 
 
 def subscribe(collection):
@@ -245,22 +211,7 @@ def subscribe(collection):
     True
     >>>
     """
-    def set_item(func):
-        collection[func.__name__] = func
-
-    try:
-        method = collection.append
-    except AttributeError:
-        try:
-            method = collection.add
-        except AttributeError:
-            method = set_item
-
-    def decorator(func):
-        method(func)
-        return func
-
-    return decorator
+    # FIXME: Implement this.
 
 
 def peek(func):
@@ -324,17 +275,7 @@ def peek(func):
     10; 20; 30.
     print(10, 20, 30, sep='; ', end='.\n') -> None
     """
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        args_reprs = [repr(arg) for arg in args]
-        kwargs_reprs = [f'{name}={value!r}' for name, value in kwargs.items()]
-        call_repr = f'{func.__name__}({", ".join(args_reprs + kwargs_reprs)})'
-        print(call_repr)
-        result = func(*args, **kwargs)
-        print(f'{call_repr} -> {result!r}')
-        return result
-
-    return wrapper
+    # FIXME: Implement this.
 
 
 def timed(func):
@@ -389,17 +330,7 @@ def timed(func):
     It has been about fifty years.
     have_patience: took 1576800000.5... s
     """
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        start = time.perf_counter()
-        try:
-            return func(*args, **kwargs)
-        finally:
-            end = time.perf_counter()
-            elapsed = end - start
-            print(f'{func.__name__}: took {elapsed:.6F} s')
-
-    return wrapper
+    # FIXME: Implement this.
 
 
 def bad_pi(func):
@@ -444,16 +375,7 @@ def bad_pi(func):
     >>> pi_times(10), math.pi
     (Fraction(220, 7), 3.141592653589793)
     """
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        old_pi = math.pi
-        math.pi = Fraction(22, 7)
-        try:
-            return func(*args, **kwargs)
-        finally:
-            math.pi = old_pi
-
-    return wrapper
+    # FIXME: Implement this.
 
 
 def monkeypatch(target, **attributes):
@@ -537,24 +459,7 @@ def monkeypatch(target, **attributes):
     >>> ns
     namespace(w=5, x=10, y=20, z=30)
     """
-    def decorator(func):
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            stack = []
-            try:
-                for name, value in attributes.items():
-                    old_value = getattr(target, name)
-                    setattr(target, name, value)
-                    stack.append((name, old_value))
-                return func(*args, **kwargs)
-            finally:
-                while stack:
-                    name, old_value = stack.pop()
-                    setattr(target, name, old_value)
-
-        return wrapper
-
-    return decorator
+    # FIXME: Implement this.
 
 
 def mock_time(func):
@@ -637,28 +542,4 @@ def mock_time(func):
     >>> abs(real3 - 0.3) < epsilon
     True
     """
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        fake_sleep_time = 0
-
-        def fake_sleep(seconds):
-            nonlocal fake_sleep_time
-            fake_sleep_time += seconds
-
-        def fake_perf_counter():
-            return old_perf_counter() + fake_sleep_time
-
-        old_sleep = time.sleep
-        old_perf_counter = time.perf_counter
-
-        time.sleep = fake_sleep
-        try:
-            time.perf_counter = fake_perf_counter
-            try:
-                return func(*args, **kwargs)
-            finally:
-                time.perf_counter = old_perf_counter
-        finally:
-            time.sleep = old_sleep
-
-    return wrapper
+    # FIXME: Implement this.

--- a/decorators.py
+++ b/decorators.py
@@ -1,4 +1,4 @@
-"""Demonstration of decorators."""
+"""Various decorators."""
 
 import functools
 from fractions import Fraction

--- a/decorators.py
+++ b/decorators.py
@@ -576,12 +576,11 @@ def mock_time(func):
     temporarily (or in some cases permanently) block the host.
 
     Therefore, as in other mocking scenarios, it's worth considering dependency
-    injection as an alternative. A function that sleeps and checks elapsed time
-    would receive its sleep and perf_counter implementations when called (or
-    perhaps would be a method of a class instantiated with them). That way, in
-    testing, it can receive mock implementations without disrupting other parts
-    of the system. But this decorator is for situations where that cannot be
-    done, or where it has been decided not to (or not at this time).
+    injection as an alternative to monkey-patching. In dependency injection, a
+    function that sleeps and checks time would receive sleep and perf_counter
+    implementations when called, or be a method of a class instantiated with
+    them. Then, in testing, it can use mock implementations without disrupting
+    other parts of the system. This decorator is for when that can't be done.
 
     The decorated function does not lose track of actually elapsed time. All
     discrepancies are due to time.sleep. When time actually passes, such as due

--- a/decorators.py
+++ b/decorators.py
@@ -1,0 +1,665 @@
+"""Demonstration of decorators."""
+
+import functools
+from fractions import Fraction
+import math
+import time
+
+
+def call(func):
+    """
+    Decorator to immediately call a function when defining it.
+
+    >>> @call
+    ... def hello():
+    ...     print('Hello, world!')
+    Hello, world!
+    >>> hello()
+    Hello, world!
+    """
+    func()
+    return func
+
+
+def twice_unary(func):
+    """
+    Decorator to call a unary function two times.
+
+    The result of the second call is returned.
+
+    >>> twice_unary(print)('Hello!')
+    Hello!
+    Hello!
+    >>> a = [5]
+    >>> twice_unary(a.append)(10)
+    >>> a
+    [5, 10, 10]
+    >>> twice_unary(a.pop)(0)  # Remove from front twice.
+    10
+    >>> a
+    [10]
+
+    >>> def square(x):
+    ...     print(f'Squaring {x}.')
+    ...     return x**2
+    >>> square = twice_unary(square)
+    >>> square(3)
+    Squaring 3.
+    Squaring 3.
+    9
+
+    >>> @twice_unary
+    ... def cube(x):
+    ...     print(f'Cubing {x}.')
+    ...     return x**3
+    >>> cube(3)
+    Cubing 3.
+    Cubing 3.
+    27
+
+    >>> square.__name__, cube.__name__
+    ('square', 'cube')
+    """
+    @functools.wraps(func)
+    def wrapper(arg):
+        func(arg)
+        return func(arg)
+
+    return wrapper
+
+
+def peek_unary(func):
+    """
+    Decorator to print calls and returns of a unary function.
+
+    >>> from fractions import Fraction
+
+    >>> @peek_unary
+    ... def square(x):
+    ...     print(f'Squaring {x}.')
+    ...     return x**2
+    >>> s = square(Fraction(1, 3))
+    square(Fraction(1, 3))
+    Squaring 1/3.
+    square(Fraction(1, 3)) -> Fraction(1, 9)
+    >>> print(s)
+    1/9
+    >>> square.__name__
+    'square'
+
+    >>> peek_unary(print)('Hello.')
+    print('Hello.')
+    Hello.
+    print('Hello.') -> None
+
+    >>> @peek_unary
+    ... def factorial(n):
+    ...     return 1 if n == 0 else n * factorial(n - 1)
+    >>> factorial(5)
+    factorial(5)
+    factorial(4)
+    factorial(3)
+    factorial(2)
+    factorial(1)
+    factorial(0)
+    factorial(0) -> 1
+    factorial(1) -> 1
+    factorial(2) -> 2
+    factorial(3) -> 6
+    factorial(4) -> 24
+    factorial(5) -> 120
+    120
+
+    >>> @peek_unary
+    ... def append_foo(target):
+    ...     target.append('foo')
+    >>> a = []
+    >>> append_foo(a)
+    append_foo([])
+    append_foo([]) -> None
+    >>> a
+    ['foo']
+    """
+    @functools.wraps(func)
+    def wrapper(arg):
+        call_repr = f'{func.__name__}({arg!r})'
+        print(call_repr)
+        result = func(arg)
+        print(f'{call_repr} -> {result!r}')
+        return result
+
+    return wrapper
+
+
+def twice(func):
+    R"""
+    Decorator to call an arbitrary function two times.
+
+    >>> a = [5]
+    >>> twice(a.append)(10)
+    >>> a
+    [5, 10, 10]
+    >>> twice(a.pop)(0)  # Remove from front twice.
+    10
+    >>> a
+    [10]
+
+    >>> @twice
+    ... def show_pair(x, y):
+    ...     print(f'{x=}, {y=}')
+    >>> show_pair('foo', 'bar')
+    x='foo', y='bar'
+    x='foo', y='bar'
+    >>> show_pair.__name__
+    'show_pair'
+
+    >>> twice(print)(10, 20, 30, sep='; ', end='.\n')
+    10; 20; 30.
+    10; 20; 30.
+    >>> show_pair(x=10, y=20)
+    x=10, y=20
+    x=10, y=20
+    >>> show_pair(11, y=22)
+    x=11, y=22
+    x=11, y=22
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        func(*args, **kwargs)
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def repeat(count):
+    R"""
+    Parameterized decorator to all a function a given number of times.
+
+    This is a parameterized decorator, also known as a decorator factory. It is
+    called with the number of repetitions, and it returns a decorator like
+    the twice decorator above, but for that number of times.
+
+    The return value from the last call is returned. If the count is zero, then
+    None is returned.
+
+    >>> repeat(3)(print)("Hello", end='!\n')
+    Hello!
+    Hello!
+    Hello!
+    >>> a = [10, 20, 30, 40, 50]
+    >>> repeat(3)(a.pop)()
+    30
+    >>> a
+    [10, 20]
+
+    >>> @repeat(3)
+    ... def f():
+    ...     a.append(a[-1]**2)
+    ...     return a[-1]
+    >>> f()
+    25600000000
+    >>> a
+    [10, 20, 400, 160000, 25600000000]
+
+    >>> repeat(1)(print)('Hello.')
+    Hello.
+    >>> repeat(0)(lambda: 42)() is None
+    True
+    """
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            result = None
+            for _ in range(count):
+                result = func(*args, **kwargs)
+            return result
+
+        return wrapper
+
+    return decorator
+
+
+def subscribe(collection):
+    """
+    Parameterized decorator to add a function to a collection when defining it.
+
+    Lists, sets, and dictionaries are supported, as are any objects that
+    support the operations of lists, sets, or dictionaries. It is acceptable to
+    assume that no unsuitable collections will ever be used.
+
+    >>> a = []
+    >>> s = set()
+    >>> d = {}
+    >>> @subscribe(a)
+    ... @subscribe(s)
+    ... @subscribe(d)
+    ... def square(n):
+    ...     return n**2
+    >>> a  # doctest: +ELLIPSIS
+    [<function square at 0x...>]
+    >>> s  # doctest: +ELLIPSIS
+    {<function square at 0x...>}
+    >>> d  # doctest: +ELLIPSIS
+    {'square': <function square at 0x...>}
+    >>> a[0] is list(s)[0] is d['square'] is square
+    True
+    >>>
+    """
+    def set_item(func):
+        collection[func.__name__] = func
+
+    try:
+        method = collection.append
+    except AttributeError:
+        try:
+            method = collection.add
+        except AttributeError:
+            method = set_item
+
+    def decorator(func):
+        method(func)
+        return func
+
+    return decorator
+
+
+def peek(func):
+    R"""
+    Decorator to print calls and returns of a function of any signature.
+
+    This is like peek_unary, but the function may take arbitrary positional and
+    keyword arguments.
+
+    >>> from fractions import Fraction
+    >>> @peek
+    ... def square(x):
+    ...     print(f'Squaring {x}.')
+    ...     return x**2
+    >>> _ = square(Fraction(1, 3))
+    square(Fraction(1, 3))
+    Squaring 1/3.
+    square(Fraction(1, 3)) -> Fraction(1, 9)
+    >>> _ = square(x=Fraction(1, 3))
+    square(x=Fraction(1, 3))
+    Squaring 1/3.
+    square(x=Fraction(1, 3)) -> Fraction(1, 9)
+
+    >>> @peek
+    ... def hypot_squared(*sides):  # TODO: Make hypot_squared a one-liner.
+    ...     acc = 0
+    ...     for side in sides:
+    ...         acc += side**2
+    ...     return acc
+    >>> hypot_squared()
+    hypot_squared()
+    hypot_squared() -> 0
+    0
+    >>> hypot_squared(2, 4, 3)
+    hypot_squared(2, 4, 3)
+    hypot_squared(2, 4, 3) -> 29
+    29
+
+    >>> import math, operator
+    >>> @peek
+    ... def fold(*xs, op):
+    ...     '''Sort of like functools.reduce, but underwhelming.'''
+    ...     return xs[0] if len(xs) == 1 else op(fold(*xs[:-1], op=op), xs[-1])
+    >>> fold(2, 14, 3, op=operator.mul) == math.prod([2, 14, 3]) == 84
+    fold(2, 14, 3, op=<built-in function mul>)
+    fold(2, 14, op=<built-in function mul>)
+    fold(2, op=<built-in function mul>)
+    fold(2, op=<built-in function mul>) -> 2
+    fold(2, 14, op=<built-in function mul>) -> 28
+    fold(2, 14, 3, op=<built-in function mul>) -> 84
+    True
+    >>> fold.__name__, fold.__doc__
+    ('fold', 'Sort of like functools.reduce, but underwhelming.')
+    >>> fold.__wrapped__(7, 5, op=operator.mul)  # Make sure to understand why.
+    fold(7, op=<built-in function mul>)
+    fold(7, op=<built-in function mul>) -> 7
+    35
+
+    >>> peek(print)(10, 20, 30, sep='; ', end='.\n')
+    print(10, 20, 30, sep='; ', end='.\n')
+    10; 20; 30.
+    print(10, 20, 30, sep='; ', end='.\n') -> None
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        args_reprs = [repr(arg) for arg in args]
+        kwargs_reprs = [f'{name}={value!r}' for name, value in kwargs.items()]
+        call_repr = f'{func.__name__}({", ".join(args_reprs + kwargs_reprs)})'
+        print(call_repr)
+        result = func(*args, **kwargs)
+        print(f'{call_repr} -> {result!r}')
+        return result
+
+    return wrapper
+
+
+def timed(func):
+    """
+    Decorator to print the elapsed time of a function, even when it fails.
+
+    This prints the elapsed time in seconds for each call of the decorated
+    function, including when the function fails with an exception. Information
+    about arguments and return values is not printed. This is for simplicity,
+    but it is also sometimes desired, because in some cases the representations
+    of one or more of those objects could be very long or expensive to compute.
+
+    The function's duration is timed with time.perf_counter. The output doesn't
+    include literal ellipses, which are doctest wildcards for the test runner.
+    Duration is reported in a fixed precision of six digits after the decimal
+    point. (The doctests below may not verify requirements in this paragraph.)
+
+    >>> import datetime, time
+
+    >>> @timed
+    ... def wait():
+    ...     time.sleep(0.125)
+    >>> wait()  # doctest: +ELLIPSIS
+    wait: took 0.12... s
+
+    >>> @timed
+    ... def fail_wait(message):
+    ...     time.sleep(0.225)
+    ...     raise ValueError(message)
+    >>> try:  # doctest: +ELLIPSIS
+    ...     fail_wait(message='refusing to say hello world')
+    ... except ValueError as error:
+    ...     print(error)
+    fail_wait: took 0.22... s
+    refusing to say hello world
+
+    >>> @timed
+    ... def wait_for(delta):
+    ...     time.sleep(delta.total_seconds())
+    ...     return delta  # Return the time delta passed in, for some reason.
+    >>> wait_for(datetime.timedelta(milliseconds=155))  # doctest: +ELLIPSIS
+    wait_for: took 0.15... s
+    datetime.timedelta(microseconds=155000)
+    >>> wait_for.__name__
+    'wait_for'
+
+    >>> @timed
+    ... def have_patience():
+    ...     time.sleep(datetime.timedelta(days=18_250).total_seconds() + 0.55)
+    ...     print('It has been about fifty years.')
+    >>> have_patience()  # TODO: Run this, somehow.  # doctest: +ELLIPSIS +SKIP
+    It has been about fifty years.
+    have_patience: took 1576800000.5... s
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        start = time.perf_counter()
+        try:
+            return func(*args, **kwargs)
+        finally:
+            end = time.perf_counter()
+            elapsed = end - start
+            print(f'{func.__name__}: took {elapsed:.6F} s')
+
+    return wrapper
+
+
+def bad_pi(func):
+    """
+    Decorator that causes a function to use the fraction 22/7 for math.pi.
+
+    Behavior of functions called before or after the decorated function must be
+    unaffected. However, correct behavior is not guaranteed if other threads
+    access math.pi, which on some Python implementations could be a data race,
+    and which on any implementation might give them the wrong value of pi, too.
+
+    For simplicity, math.tau is unaffected, but it is also not used in any way.
+    The better value of pi is not hard-coded except in the tests, nor computed.
+
+    >>> @bad_pi
+    ... def circle_area(radius):
+    ...     return math.pi * radius**2
+    >>> math.pi
+    3.141592653589793
+    >>> circle_area(10), circle_area(radius=10)
+    (Fraction(2200, 7), Fraction(2200, 7))
+    >>> math.pi, circle_area.__wrapped__(10)
+    (3.141592653589793, 314.1592653589793)
+
+    >>> @bad_pi
+    ... def unit_pizza_slice_area(slice_count):
+    ...     return math.pi / slice_count
+    >>> unit_pizza_slice_area(slice_count=2)  # Acceptable. We "eta" pizza.
+    Fraction(11, 7)
+    >>> unit_pizza_slice_area(slice_count=1j)  # Acceptable.
+    -3.142857142857143j
+    >>> unit_pizza_slice_area(slice_count=0)  # Unacceptable.
+    Traceback (most recent call last):
+      ...
+    ZeroDivisionError: Fraction(1, 0)
+    >>> math.pi
+    3.141592653589793
+
+    >>> @bad_pi
+    ... def pi_times(multiplier):
+    ...     return 0 if multiplier == 0 else pi_times(multiplier - 1) + math.pi
+    >>> pi_times(10), math.pi
+    (Fraction(220, 7), 3.141592653589793)
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        old_pi = math.pi
+        math.pi = Fraction(22, 7)
+        try:
+            return func(*args, **kwargs)
+        finally:
+            math.pi = old_pi
+
+    return wrapper
+
+
+def monkeypatch(target, **attributes):
+    """
+    Decorator factory for setting attributes on a target object temporarily.
+
+    When a function is decorated using an expression that is a call to this
+    parameterized decorator, it causes the decorated function to patch in the
+    attributes passed as keyword arguments when called, and to unpatch them
+    when control exits it (either by returning or due to an exception).
+
+    Attributes are unpatched in the reverse of the order in which they are
+    patched. Although an exception from the decorated function must not prevent
+    unpatching, if an exception is raised while attempting to unpatch an
+    attribute then any remaining still-patched attributes won't be unpatched.
+    However, if patching an attribute fails, then any attributes already
+    patched will still be unpatched (and still in reverse order).
+
+    Functions decorated with @monkeypatch(...) may themselves be recursive, but
+    recursion is not used in any way in the implementation of monkeypatch.
+    Decorating a function @monkeypatch(target, **attributes) augments its time
+    and space complexity by O(attributes), and never more.
+
+    For simplicity, it is assumed that all attributes to patch already exist.
+    However, if that turns out not to be the case, then the above requirements
+    still hold with respect to any resulting exceptions.
+
+    TODO: Eventually implement setting and deleting formerly absent attributes.
+
+    >>> @monkeypatch(math, pi=Fraction(22, 7), tau=Fraction(44, 7))
+    ... def circle_area(radius):
+    ...     by_pi = math.pi * radius**2
+    ...     by_tau = math.tau * radius**2 / 2
+    ...     assert by_pi == by_tau
+    ...     return by_pi
+    >>> math.pi, math.tau
+    (3.141592653589793, 6.283185307179586)
+    >>> circle_area(10)
+    Fraction(2200, 7)
+    >>> math.pi, math.tau
+    (3.141592653589793, 6.283185307179586)
+
+    >>> @monkeypatch(math, pi=Fraction(22, 7), tau=Fraction(44, 7))
+    ... def raise_error():
+    ...     raise ValueError('changing the value of pi (and tau) is absurd')
+    >>> raise_error()
+    Traceback (most recent call last):
+      ...
+    ValueError: changing the value of pi (and tau) is absurd
+    >>> math.pi, math.tau
+    (3.141592653589793, 6.283185307179586)
+
+    >>> import builtins
+    >>> @monkeypatch(builtins, input=lambda *args: 'Countess von Willdebrandt')
+    ... def interactive_hello():
+    ...     name = input('What is your name? ')
+    ...     print(f'Hello, {name}!')
+    >>> input
+    <built-in function input>
+    >>> interactive_hello()
+    Hello, Countess von Willdebrandt!
+    >>> input
+    <built-in function input>
+
+    >>> from types import SimpleNamespace
+    >>> ns = SimpleNamespace(w=5, x=10, y=20, z=30)
+    >>> @monkeypatch(ns, w=2, x=11, z=33)
+    ... def f():
+    ...     print(ns)
+    >>> ns
+    namespace(w=5, x=10, y=20, z=30)
+    >>> f()
+    namespace(w=2, x=11, y=20, z=33)
+    >>> @monkeypatch(ns, w=2, x=11, y=22, __class__=int, z=33)
+    ... def g():
+    ...     print(ns)
+    >>> g()  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+      ...
+    TypeError: __class__ assignment only supported for mutable types or ...
+    >>> ns
+    namespace(w=5, x=10, y=20, z=30)
+    """
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            stack = []
+            try:
+                for name, value in attributes.items():
+                    old_value = getattr(target, name)
+                    setattr(target, name, value)
+                    stack.append((name, old_value))
+                return func(*args, **kwargs)
+            finally:
+                while stack:
+                    name, old_value = stack.pop()
+                    setattr(target, name, old_value)
+
+        return wrapper
+
+    return decorator
+
+
+def mock_time(func):
+    """
+    Decorator to cause time.sleep to only simulate the passage of time.
+
+    Adding this decorator to a function definition makes the function think its
+    calls to time.sleep (and those due to functions it calls) have taken the
+    amount of time, in seconds, passed to time.sleep, at least if the function
+    uses time.perf_counter to check. But it is a lie. Instead, time.sleep and
+    time.perf_counter conspire to lie to it.
+
+    It is dangerous to mock time. The lie is told to functions called by the
+    decorated function that themselves use time.sleep and time.perf_counter, as
+    well as affecting any code running on another thread between when the
+    decorated function is called and when it returns. In particular, if
+    time.sleep is used to wait between performing actions over a network that
+    must be rate limited, such as requests to a REST API, then the host may
+    temporarily (or in some cases permanently) block the host.
+
+    Therefore, as in other mocking scenarios, it's worth considering dependency
+    injection as an alternative. A function that sleeps and checks elapsed time
+    would receive its sleep and perf_counter implementations when called (or
+    perhaps would be a method of a class instantiated with them). That way, in
+    testing, it can receive mock implementations without disrupting other parts
+    of the system. But this decorator is for situations where that cannot be
+    done, or where it has been decided not to (or not at this time).
+
+    The decorated function does not lose track of actually elapsed time. All
+    discrepancies are due to time.sleep. When time actually passes, such as due
+    to a computation, that is reflected in the passage of time as shown by
+    time.perf_counter.
+
+    >>> import datetime, time
+    >>> epsilon = 0.005
+
+    >>> @mock_time
+    ... def sleep_ten(throw):
+    ...     start = time.perf_counter()
+    ...     time.sleep(10)
+    ...     elapsed = time.perf_counter() - start
+    ...     if not throw:
+    ...         return elapsed
+    ...     ex = ValueError()
+    ...     ex.elapsed = elapsed
+    ...     raise ex
+
+    >>> start = time.perf_counter()
+    >>> fake1 = sleep_ten(False)
+    >>> real1 = time.perf_counter() - start
+    >>> abs(fake1 - 10) < epsilon
+    True
+    >>> abs(real1) < epsilon
+    True
+
+    >>> start = time.perf_counter()
+    >>> try:
+    ...     sleep_ten(True)
+    ... except ValueError as ex:
+    ...     fake2 = ex.elapsed
+    >>> real2 = time.perf_counter() - start
+    >>> abs(fake2 - 10) < epsilon
+    True
+    >>> abs(real2) < epsilon
+    True
+
+    >>> @mock_time
+    ... def heterogeneous_wait(spin_time, sleep_time, reps):
+    ...     full_start = time.perf_counter()
+    ...     for _ in range(reps):
+    ...         spin_start = time.perf_counter()
+    ...         while time.perf_counter() - spin_start < spin_time:
+    ...             pass
+    ...         time.sleep(sleep_time)
+    ...     return time.perf_counter() - full_start
+    >>> start = time.perf_counter()
+    >>> fake3 = heterogeneous_wait(spin_time=0.1, sleep_time=1000, reps=3)
+    >>> real3 = time.perf_counter() - start
+    >>> abs(fake3 - 3000.3) < epsilon
+    True
+    >>> abs(real3 - 0.3) < epsilon
+    True
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        fake_sleep_time = 0
+
+        def fake_sleep(seconds):
+            nonlocal fake_sleep_time
+            fake_sleep_time += seconds
+
+        def fake_perf_counter():
+            return old_perf_counter() + fake_sleep_time
+
+        old_sleep = time.sleep
+        old_perf_counter = time.perf_counter
+
+        time.sleep = fake_sleep
+        try:
+            time.perf_counter = fake_perf_counter
+            try:
+                return func(*args, **kwargs)
+            finally:
+                time.perf_counter = old_perf_counter
+        finally:
+            time.sleep = old_sleep
+
+    return wrapper


### PR DESCRIPTION
This adds more exercises on the topic of decorators, a subtopic of higher-order functions.

There were already some such exercises in `caching.py`. This improves those and their tests, and adds more. In addition, it adds a new module `decorators.py` which has a number of exercises in it. In view of the improvements in `caching.py`, as well as the benefit (I think) of working the exercises in `decorators.py` before the ones in `caching.py`, I recommend merging this before doing anything with `caching.py` (even though that file does already exist on the main branch). In contrast, these do not interfere with exercises in other files.

As in #3, my somewhat unusual recommendation (for a pull request) applies here as well: If you avoid examining the diffs of individual commits in this pull request, you can avoid spoilers and facilitate and independent re-working of the exercises (but examining the overall diff of the pull request, in the "Files changed" tab, would not lead to this problem).