### PR TITLE
functools.partial: improve naming and add one exercise

### DIFF
--- a/adders.py
+++ b/adders.py
@@ -27,24 +27,24 @@ def make_adder(left_addend):
     return adder
 
 
-def make_adder_alt(left_addend):
+def make_adder_l(left_addend):
     """
     Make a function that adds left_addend and the value it is called with.
 
     This is an alternative implementation of make_adder, satisfying all the
-    same outward requirements. One uses a lambda and the other does not.
+    same outward requirements. This implementation uses a lambda expression.
 
-    >>> f = make_adder_alt(3)
+    >>> f = make_adder_l(3)
     >>> f(7)
     10
     >>> f(-2)
     1
-    >>> _ = make_adder_alt(10)
+    >>> _ = make_adder_l(10)
     >>> f(5)
     8
-    >>> make_adder_alt('foo')('bar')
+    >>> make_adder_l('foo')('bar')
     'foobar'
-    >>> make_adder_alt([10, 20, 30])([40, 50])
+    >>> make_adder_l([10, 20, 30])([40, 50])
     [10, 20, 30, 40, 50]
     """
     return lambda right_addend: left_addend + right_addend

--- a/adders.py
+++ b/adders.py
@@ -1,8 +1,5 @@
 """Higher-order functions for adding."""
 
-import functools
-import operator
-
 
 def make_adder(left_addend):
     """
@@ -73,7 +70,7 @@ def make_adder_p(left_addend):
     >>> make_adder_p([10, 20, 30])([40, 50])
     [10, 20, 30, 40, 50]
     """
-    return functools.partial(operator.add, left_addend)
+    # FIXME: Implement this.
 
 
 def make_adder_intro(left_addend):

--- a/adders.py
+++ b/adders.py
@@ -1,5 +1,8 @@
 """Higher-order functions for adding."""
 
+import functools
+import operator
+
 
 def make_adder(left_addend):
     """
@@ -48,6 +51,29 @@ def make_adder_l(left_addend):
     [10, 20, 30, 40, 50]
     """
     return lambda right_addend: left_addend + right_addend
+
+
+def make_adder_p(left_addend):
+    """
+    Make a function that adds left_addend and the value it is called with.
+
+    This achieves an effect like make_adder and make_adder_p, but this uses
+    functools.partial, defining no functions (with neither "def" nor "lambda").
+
+    >>> f = make_adder_p(3)
+    >>> f(7)
+    10
+    >>> f(-2)
+    1
+    >>> _ = make_adder_p(10)
+    >>> f(5)
+    8
+    >>> make_adder_p('foo')('bar')
+    'foobar'
+    >>> make_adder_p([10, 20, 30])([40, 50])
+    [10, 20, 30, 40, 50]
+    """
+    return functools.partial(operator.add, left_addend)
 
 
 def make_adder_intro(left_addend):

--- a/composers.py
+++ b/composers.py
@@ -20,20 +20,19 @@ def compose2(f, g):
     return lambda x: f(g(x))
 
 
-def compose2_alt(f, g):
+def compose2_l(f, g):
     """
     Compose the unary functions f and g. Alternative implementation.
 
     This behaves the same as compose2, but they are implemented differently.
-    One implementation uses a lambda expression and is a single line long. The
-    other uses no lambda expressions (though its doctests do).
+    This uses no lambda expressions (besides those appearing in its doctests).
 
-    >>> h = compose2_alt(lambda x: x + 1, lambda x: x * 2)
+    >>> h = compose2_l(lambda x: x + 1, lambda x: x * 2)
     >>> h(0)
     1
     >>> h(5)
     11
-    >>> compose2_alt(len, lambda x: x * 3)('foobar')
+    >>> compose2_l(len, lambda x: x * 3)('foobar')
     18
     """
     def fog(x):
@@ -194,26 +193,26 @@ def curry_one_l(func):
     return lambda x: lambda y: func(x,y)
 
 
-def curry_one_alt(func):
+def curry_one_p(func):
     """
-    Curry a binary function. Alternative implementation.
+    Curry a binary function, using functools.partial.
 
     This achieves an effect like that of curry_one, but they are implemented
-    differently. One of them uses functools.partial and the other does not.
+    differently. This implementation uses functools.partial.
 
-    >>> curry_one_alt(pow)(2)(10)
+    >>> curry_one_p(pow)(2)(10)
     1024
 
     >>> import math, operator
 
-    >>> f = curry_one_alt(operator.sub)
+    >>> f = curry_one_p(operator.sub)
     >>> subtract_from_three = f(3)
     >>> subtract_from_three(5)
     -2
     >>> subtract_from_three(1)
     2
 
-    >>> g = curry_one_alt(math.perm)
+    >>> g = curry_one_p(math.perm)
     >>> g(10)(3)
     720
     >>> g(10)(10)


### PR DESCRIPTION
This changes the function name suffixes uses to distinguish implementations using `functools.partial` from others, while still distinguishing others from each other.

It also adds one new exercise, in `adders.py`: a `make_adder` implementation using `functools.partial`.