### PR TITLE
Add old Rainbow Brackets extension to dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,7 @@
     "customizations": {
         "vscode": {
             "extensions": [
+                "2gua.rainbow-brackets",
                 "alefragnani.numbered-bookmarks",
                 "bierner.markdown-preview-github-styles",
                 "eamodio.gitlens",


### PR DESCRIPTION
I believe this is an improvement because VS Code's bracket pair colorization feature doesn't apply inside docstrings, and hiss has some doctests whose clarity is improved by colorizing nested matching pairs of parentheses, square brackets, and curly braces.

Unfortunately, this extension is deprecated, based on the erroneous belief that VS Code's bracket pair colorization feature does everything it can (that feature is great overall, especially where performance is concerned, but it does not highlight matching brackets in docstrings). This gives an annoying warning. The warning can be disabled, but not for individual extensions, and re-enabling it is nontrivial. I have no great solution to this. The warning can be dismissed every time VS Code is run, or it can be disabled and a manual check done for deprecated extensions from time to time.

There are non-deprecated VS Code extensions for bracket pair colorization, but all the ones I've found besides this one will either not highlight brackets in docstrings, or identify brackets *incorrectly* a significant fraction of the time.

References:

- [How can I get bracket pair colorization inside strings in VS Code?](https://stackoverflow.com/questions/71093558/how-can-i-get-bracket-pair-colorization-inside-strings-in-vs-code) (Stack Overflow)
- https://github.com/microsoft/vscode/issues/146453
- https://github.com/microsoft/vscode/issues/24815
- https://github.com/EliahKagan/palgoviz/pull/191