### PR TITLE
Add pytest as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 doctestfn
 graphviz
 ipykernel
+pytest


### PR DESCRIPTION
This adds pytest as a dependency. Initially we are likely to use this as a test runner for doctests, since it is often a more convenient way to run doctests than `python -m doctest` or `doctestfn`, and also because VS Code supports it, so this will facilitate visual test discovery, running, and result inspection. Later, we are likely to have actual pytest and/or unittest tests, which the pytest runner can also run. (If we only had unittest tests, the unittest runner would be sufficient; the pytest runner will run pytest, unittest, doctest, and some other kinds of tests.)

Although pytest will benefit from being configured, this does not do that. By adding the dependency, newly created codespaces will have the package automatically installed. pytest is useful even without special configuration, and configuring it is typically quick.