### PR TITLE
Set up some CI checks

### DIFF
--- a/.devcontainer/onCreate
+++ b/.devcontainer/onCreate
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# shellcheck disable=SC1091  # Not checking .venv/bin/activate.
+
 set -eu
 
 # Customize git configuration for shell prompt and terminal colors.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: '/'
+  schedule:
+    interval: daily

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: Lint
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+
+    - name: Run Ruff
+      uses: chartboost/ruff-action@v1

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,14 @@
+name: ShellCheck
+
+on: [push, pull_request]
+
+jobs:
+  shellcheck:
+    runs-on: [ubuntu-latest]
+
+    steps:
+    - name: Check out source repository
+      uses: actions/checkout@v4
+
+    - name: Analyze shell scripts
+      uses: bewuethr/shellcheck-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Test
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.12']
+      fail-fast: false
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Update PyPA packages
+      run: |
+        # Get the latest pip, wheel, and prior to Python 3.12, setuptools.
+        python -m pip install -U pip $(pip freeze --all | grep -oF setuptools) wheel
+
+    - name: Install project dependencies
+      run: pip install -r requirements.txt
+
+    - name: Test with pytest
+      run: pytest --color=yes --doctest-modules -vv

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,25 +1,19 @@
-name: Test
+name: Typecheck
 
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  test:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.12']
-      fail-fast: false
-
-    runs-on: ${{ matrix.os }}
+  pyright:
+    runs-on: ubuntu-latest
 
     steps:
     - name: Check out repository
       uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.12'
 
     - name: Update PyPA packages
       run: |
@@ -29,5 +23,5 @@ jobs:
     - name: Install project dependencies
       run: pip install -r requirements.txt
 
-    - name: Test with pytest
-      run: pytest --color=yes --doctest-modules -vv
+    - name: Run pyright
+      uses: jakebailey/pyright-action@v1

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,3 @@
+{
+    "reportFunctionMemberAccess": false
+}


### PR DESCRIPTION
This sets up automated checks with [GitHub Actions](https://docs.github.com/en/actions), so that on each push, and on each pull request, GitHub runs:

- [pytest](https://docs.pytest.org/en/7.4.x/), to run [unit tests](https://en.wikipedia.org/wiki/Unit_testing) (see also [#11](https://github.com/tfallon0/hiss/pull/11)), which so far are our [doctests](https://docs.python.org/3/library/doctest.html).
- [pyright](https://github.com/microsoft/pyright) (via [pyright-python](https://github.com/RobertCraigie/pyright-python)) for static type checking (see also [#18](https://github.com/tfallon0/hiss/pull/18)).
- [ruff](https://docs.astral.sh/ruff/), for [linting](https://en.wikipedia.org/wiki/Lint_(software)) and [style](https://pep8.org/) checking (see also [#12](https://github.com/tfallon0/hiss/pull/12)).
- [shellcheck](https://www.shellcheck.net/), to lint the shell scripts used to set up the dev container (from [#2](https://github.com/tfallon0/hiss/pull/2)).

Because this repository does not yet have any CI checks, this PR may not cause any to run until it is merged (even though, going forward, PRs opened by users who have had a PR merged before would have CI checks run automatically). However, you can see them at the tip of [my feature branch](https://github.com/EliahKagan/hiss/commits/ci/).

"CI checks" are associated with [continuous integration](https://en.wikipedia.org/wiki/Continuous_integration), since they make it feasible to do that. But using them in a project, as proposed here, does not itself impose any particular development methodology.

The testing and ruff checks do not currently pass, because some existing functions in the project are only partly implemented, or are not yet implemented at all. I regard this to be okay. Eventually, it might become the case that the norm is for all CI checks to pass. Full details of each CI run are available, including the specific output of all checks. You can examine the output of the ruff check to see the unused variable it is warning about it (which is just due to a partially completed implementation). You can likewise examine the output of the unit testing checks to see which functions have working implementations at this time and which do not. Eventually it might make sense to keep the main branch "clean," with passing CI checks, and develop new features on their own branches, which are merged into main. But whether or not that will ever make sense to do, I think there is some benefit to be gained by enabling CI checks now.

GitHub Actions workflows (the `.yml` files in `.github/workflows`) define jobs GitHub runs on virtual machines in response to various event triggers. Each step of a job either runs a command or uses a predefined *action*. This causes the project to have not only Python dependencies (currently in `requirements.txt`), but also GitHub Actions dependencies. To avoid introducing a burden of managing their versions manually, this PR also adds a `dependabot.yml` file, enabling [Dependabot version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates). When a new version of a dependency is available, [Dependabot](https://docs.github.com/en/code-security/dependabot) opens a pull request automatically. Our automated checks run in this PR, so you can check if the updated dependencies would cause (or fix) problems.

This project's most important dependencies remain its Python dependencies, obtained from [PyPI](https://pypi.org/) by `pip`. Dependabot version updates support Python dependencies, too. However, we do not currently pin specific versions of our Python dependencies--no version numbers or ranges appear in our `requirements.txt`--so there would be no benefit of enabling Dependabot version updates for the Python dependencies at this time. Therefore, I have only configured version updates for GitHub Actions dependencies in `dependabot.yml`. My *guess* is that Dependabot version updates for Python dependencies might become useful for this project at some point in the future, whereupon they could be added.

Unlike GitHub Codespaces, for which unpaid usage is capped per account on both public and private repositories, on public repositories there are no caps on free-as-in-beer GitHub Actions or Dependabot usage. (There is rate limiting: for each operating system, only a limited number of GitHub Actions runners are available to you at any one time. When a job needs a runner but this cap is reached, it simply waits automatically for other jobs to finish so that the runner it needs is available, and then runs.)

While I've enabled testing on Ubuntu, macOS, and Windows, which can help find code that is unintentionally nonportable, I've only enabled testing with Python 3.12. This is because I suspect we will end up using features that were introduced in Python 3.12, such as [the new syntax for type parameters](https://peps.python.org/pep-0695/). However, I have written the test workflow as being parameterized by both operating system and Python version, so other versions can easily be added later, if desired. If and when this is done, all combinations of listed OS and Python version will have jobs generated for them. For example, if we were to list all Python versions from 3.8 to 3.12, then since we have three operating systems listed, 15 jobs would be generated.

---

In addition to these changes, there are some related changes I recommend making (if you have not done so already) that cannot by made by a pull request. In the repository's *Settings → Code security and analysis*, I recommend:

- Enabling [Dependabot alerts](https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts), which tell you about security vulnerabilities in dependencies.
- Enabling [Dependabot security updates](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates), which whenever possible open pull requests to upgrade vulnerable dependencies to versions in which vulnerabilities have been fixed. These PRs are opened as soon as possible (rather than on a set schedule), apply automatically to all kinds of dependencies (so they will automatically work for the Python dependencies if and when versions are specified for them), work even when technical problems interfere with the operation of Dependabot version updates (or when version updates are not enabled), and the GitHub user interface clearly shows the relationship between the PR and the advisory for the security vulnerability it addresses. (They are still not *merged* automatically, only opened automatically.)
- Enabling [CodeQL analysis](https://codeql.github.com/). This scans the code for bugs, with a focus on security, but other bugs can be found, as well. It works by maintaining a database of a large number of patterns that bugs relevant to security have been found to take, and scanning the code for those patterns. For starters, I recommend enabling [the "Default" configuration](https://docs.github.com/en/code-security/code-scanning/enabling-code-scanning/configuring-default-setup-for-code-scanning#about-default-setup), which is easily done from the repository settings. It does not involve adding or changing any files in the repository, which is why it cannot be done by PR. An "Advanced" configuration allows further customizability and is put in place by adding a `.yml` workflow file. Although I could've included such a workflow in this PR, I think it makes more sense to start out with the "Default" configuration.
- Enabling [secret scanning](https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning). This scans for text that strongly appears to be a secret, such as an API key to access an online service, that was unintentionally pushed to the repository. It thus provides a significant measure of protection against inadvertently leaking access credentials that someone could use to impersonate, or spend the money of, your or another contributor to the project. This is most useful for projects that use secrets, such as a project that uses a machine learning model through an API such as that of HuggingFace or OpenAI, but it is is occasionally beneficial otherwise and I suggest enabling it in all public repositories. Actually, *most* secret scanning is done automatically whether you enable it or not. The main benefit of enabling it is that GitHub tells *you* when it finds something that looks like a secret, rather than just the company/service it looks like the secret is for so that they can invalidate the key. (Secret scanning applies only to public repositories. Although we shouldn't commit access credentials to private repositories either, it's public repositories where attackers can, and do, perform their own scans for secrets to use. Secret scanning thus serves to provide, for defensive security, a capability offensive security has long enjoyed.)
- Enabling [push protection](https://docs.github.com/en/enterprise-cloud@latest/code-security/secret-scanning/push-protection-for-repositories-and-organizations). If you enable secret scanning, you are given the further option to turn on push protection, so that running `git push` when one or more commits appears to contain a detectable secret *fails* and the secret doesn't make its way into the remote repository in the first place. I view this as one of the key benefits of enabling secret scanning in repository settings. Note that enabling secret scanning does not turn on push protection, at least not as of this writing. You have to check the box for "push protection" too. It is rare that non-secrets are wrongly detected as likely secrets (I have never heard of this happening, actually), but if that were to happen, you can go back into the repository settings and turn this off.