### PR TITLE
Make the type annotations generic

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -38,6 +38,9 @@ extend-select = [
 ]
 line-length = 97
 ignore = [
+    # undocumented-magic-method (Dunder methods often don't need a docstring.)
+    "D105",
+
     # one-blank-line-before-class (Using D211 blank-line-before-class instead.)
     # D211 enforces no blank line between a class header and class docstring.
     "D203",

--- a/dicts.py
+++ b/dicts.py
@@ -27,14 +27,11 @@ def invert[K: Hashable, V: Hashable](d: dict[K,V]) -> dict[V,K]:
 
 
 @overload
-def distinct[T](
-    values: Iterable[T], *, key: Callable[[T],Hashable],
-) -> list[T]: ...
+def distinct[T](values: Iterable[T], *, key: Callable[[T],Hashable]) -> list[T]: ...
 
 
 @overload
-def distinct[T: Hashable](values: Iterable[T], *, key: None = ...) -> list[T]:
-    ...
+def distinct[T: Hashable](values: Iterable[T], *, key: None = ...) -> list[T]: ...
 
 
 def distinct(values, *, key = None):
@@ -61,9 +58,7 @@ def distinct(values, *, key = None):
     return val_list
 
 
-def sorted_al[T: HashableSortable](
-    adj_list: dict[T,set[T]],
-) -> dict[T,list[T]]:
+def sorted_al[T: HashableSortable](adj_list: dict[T,set[T]]) -> dict[T,list[T]]:
     """
     Sort an adjacency list.
 
@@ -78,11 +73,8 @@ def sorted_al[T: HashableSortable](
 
 
 def adjacency[T: Hashable](
-    edges: list[tuple[T,T]],
-    vertices: Iterable[T] = (),
-    *,
-    directed: bool = True,
-) -> dict[T,set[T]]:
+        edges: list[tuple[T,T]], vertices: Iterable[T] = (), *, directed: bool = True,
+    ) -> dict[T,set[T]]:
     """
     Make an adjacency list.
 
@@ -209,8 +201,8 @@ def components[T: Hashable](edges: list[tuple[T,T]]) -> set[frozenset[T]]:
 
 
 def components_d[T: Hashable](
-    edges: list[tuple[T,T]], vertices: Iterable[T] = (),
-) -> set[frozenset[T]]:
+        edges: list[tuple[T,T]], vertices: Iterable[T] = (),
+    ) -> set[frozenset[T]]:
     """
     Identify the connected components from an edge list.
 
@@ -225,8 +217,8 @@ def components_d[T: Hashable](
 
 
 def _setofsets[K: Hashable, T: Hashable](
-    set_dict: Mapping[K,Iterable[T]],
-) -> set[frozenset[T]]:
+        set_dict: Mapping[K,Iterable[T]],
+    ) -> set[frozenset[T]]:
     """Make a set of frozensets (components_d must assure preconditions)."""
     vals = set()
     for val in distinct(set_dict.values(), key=id):
@@ -235,8 +227,8 @@ def _setofsets[K: Hashable, T: Hashable](
 
 
 def _setofsets_alt[K: Hashable, T: Hashable](
-    set_dict: Mapping[K,Iterable[T]],
-) -> set[frozenset[T]]:
+        set_dict: Mapping[K,Iterable[T]],
+    ) -> set[frozenset[T]]:
     """Make a set of frozensets (like _setofsets, same preconditions)."""
     list_of_sets = distinct(set_dict.values(), key=id)
     return set(map(frozenset, list_of_sets))
@@ -246,8 +238,8 @@ def _setofsets_alt[K: Hashable, T: Hashable](
 
 
 def components_dict[T: Hashable](
-    edges: list[tuple[T,T]], vertices: Iterable[T] = (),
-) -> dict[T,list[T]]:
+        edges: list[tuple[T,T]], vertices: Iterable[T] = (),
+    ) -> dict[T,list[T]]:
     """
     Identify the connected components from an edge list.
 
@@ -286,8 +278,8 @@ def components_dict[T: Hashable](
 
 
 def components_dict_alt[T: Hashable](
-    edges: list[tuple[T,T]], vertices: Iterable[T] = (),
-) -> dict[T,list[T]]:
+        edges: list[tuple[T,T]], vertices: Iterable[T] = (),
+    ) -> dict[T,list[T]]:
     """
     Identify the connected components from an edge list.
 
@@ -326,8 +318,8 @@ def components_dict_alt[T: Hashable](
 
 # FIXME: Actually implement classic quick-find.
 def components_dict_alt2[T: Hashable](
-    edges: list[tuple[T,T]], vertices: Iterable[T] = (),
-) -> dict[T,list[T]]:
+        edges: list[tuple[T,T]], vertices: Iterable[T] = (),
+    ) -> dict[T,list[T]]:
     """
     Identify the connected components from an edge list.
 
@@ -361,8 +353,8 @@ def components_dict_alt2[T: Hashable](
 
 
 def components_dfs[T: Hashable](
-    edges: list[tuple[T,T]], vertices: Iterable[T] = (),
-) -> set[frozenset[T]]:
+        edges: list[tuple[T,T]], vertices: Iterable[T] = (),
+    ) -> set[frozenset[T]]:
     """
     Identify the connected components from an edge list.
 
@@ -415,8 +407,8 @@ def devious() -> list[tuple[str,str]]:
 
 # FIXME: Finish implementing this.
 def components_dfs_iter[T: Hashable](
-    edges: list[tuple[T,T]], vertices: Iterable[T] = (),
-) -> set[frozenset[T]]:
+        edges: list[tuple[T,T]], vertices: Iterable[T] = (),
+    ) -> set[frozenset[T]]:
     """
     Identify the connected components from an edge list.
 

--- a/dicts.py
+++ b/dicts.py
@@ -61,7 +61,7 @@ def distinct(values, *, key = None):
     return val_list
 
 
-def sorted_al[T: HashableSortable](
+def sorted_al[T: HashableSortable[T]](
     adj_list: dict[T,set[T]],
 ) -> dict[T,list[T]]:
     """

--- a/dicts.py
+++ b/dicts.py
@@ -1,6 +1,6 @@
 """Functions dealing with dictionaries."""
 
-from collections.abc import Callable, Hashable, Iterable
+from collections.abc import Callable, Hashable, Iterable, Mapping
 from typing import overload
 
 import graphviz
@@ -61,7 +61,7 @@ def distinct(values, *, key = None):
     return val_list
 
 
-def sorted_al[T: HashableSortable[T]](
+def sorted_al[T: HashableSortable](
     adj_list: dict[T,set[T]],
 ) -> dict[T,list[T]]:
     """
@@ -158,7 +158,7 @@ def draw_graph[T](adj_list: dict[T,set[T]]) -> graphviz.Digraph:
 
 
 # TODO: Modify this to use a comprehension.
-def sorted_setoset[T](unsorted: set[frozenset[T]]) -> list[list[T]]:
+def sorted_setoset[T: HashableSortable](unsorted: set[frozenset[T]]) -> list[list[T]]:
     """Convert a family of (frozen)sets into a nested list."""
     unsorted_list = []
     for collection in unsorted:
@@ -224,8 +224,8 @@ def components_d[T: Hashable](
     return _setofsets(components_dict(edges, vertices))
 
 
-def _setofsets[T: Hashable](
-    set_dict: dict[object,Iterable[T]],
+def _setofsets[K: Hashable, T: Hashable](
+    set_dict: Mapping[K,Iterable[T]],
 ) -> set[frozenset[T]]:
     """Make a set of frozensets (components_d must assure preconditions)."""
     vals = set()
@@ -234,8 +234,8 @@ def _setofsets[T: Hashable](
     return vals
 
 
-def _setofsets_alt[T: Hashable](
-    set_dict: dict[object,Iterable[T]],
+def _setofsets_alt[K: Hashable, T: Hashable](
+    set_dict: Mapping[K,Iterable[T]],
 ) -> set[frozenset[T]]:
     """Make a set of frozensets (like _setofsets, same preconditions)."""
     list_of_sets = distinct(set_dict.values(), key=id)

--- a/dicts.py
+++ b/dicts.py
@@ -5,6 +5,7 @@ from typing import overload
 
 import graphviz
 
+from protocols import HashableSortable
 from util import identity_function
 
 
@@ -60,7 +61,9 @@ def distinct(values, *, key = None):
     return val_list
 
 
-def sorted_al[T: Hashable](adj_list: dict[T,set[T]]) -> dict[T,list[T]]:
+def sorted_al[T: HashableSortable](
+    adj_list: dict[T,set[T]],
+) -> dict[T,list[T]]:
     """
     Sort an adjacency list.
 

--- a/dicts.py
+++ b/dicts.py
@@ -1,13 +1,14 @@
 """Functions dealing with dictionaries."""
 
-from collections.abc import Iterable
+from collections.abc import Callable, Hashable, Iterable
+from typing import overload
 
 import graphviz
 
 from util import identity_function
 
 
-def invert(d: dict) -> dict:
+def invert[K: Hashable, V: Hashable](d: dict[K,V]) -> dict[V,K]:
     """
     Invert the dictionary.
 
@@ -24,7 +25,18 @@ def invert(d: dict) -> dict:
     return inv_d
 
 
-def distinct(values: Iterable, *, key=None) -> list:
+@overload
+def distinct[T](
+    values: Iterable[T], *, key: Callable[[T],Hashable],
+) -> list[T]: ...
+
+
+@overload
+def distinct[T: Hashable](values: Iterable[T], *, key: None = ...) -> list[T]:
+    ...
+
+
+def distinct(values, *, key = None):
     """
     Create a list with every value of the values, but without repeating any.
 
@@ -48,7 +60,7 @@ def distinct(values: Iterable, *, key=None) -> list:
     return val_list
 
 
-def sorted_al(adj_list: dict[str,set[str]]) -> dict[str,list[str]]:
+def sorted_al[T: Hashable](adj_list: dict[T,set[T]]) -> dict[T,list[T]]:
     """
     Sort an adjacency list.
 
@@ -62,12 +74,12 @@ def sorted_al(adj_list: dict[str,set[str]]) -> dict[str,list[str]]:
     return sl
 
 
-def adjacency(
-    edges: list[tuple[str,str]],
-    vertices: Iterable[str] = (),
+def adjacency[T: Hashable](
+    edges: list[tuple[T,T]],
+    vertices: Iterable[T] = (),
     *,
     directed: bool = True,
-) -> dict[str,set[str]]:
+) -> dict[T,set[T]]:
     """
     Make an adjacency list.
 
@@ -120,8 +132,7 @@ def adjacency(
     return adj_list
 
 
-# TODO: The parameter annotation is too narrow. Use abstract types instead.
-def draw_graph(adj_list: dict[str,set[str]]) -> graphviz.Digraph:
+def draw_graph[T](adj_list: dict[T,set[T]]) -> graphviz.Digraph:
     R"""
     Draw a directed graph.
 
@@ -144,7 +155,7 @@ def draw_graph(adj_list: dict[str,set[str]]) -> graphviz.Digraph:
 
 
 # TODO: Modify this to use a comprehension.
-def sorted_setoset(unsorted: set[frozenset]) -> list[list]:
+def sorted_setoset[T](unsorted: set[frozenset[T]]) -> list[list[T]]:
     """Convert a family of (frozen)sets into a nested list."""
     unsorted_list = []
     for collection in unsorted:
@@ -152,7 +163,7 @@ def sorted_setoset(unsorted: set[frozenset]) -> list[list]:
     return sorted(unsorted_list)
 
 
-def components(edges: list[tuple[str,str]]) -> set[frozenset[str]]:
+def components[T: Hashable](edges: list[tuple[T,T]]) -> set[frozenset[T]]:
     """
     Identify the connected components from an edge list.
 
@@ -194,10 +205,9 @@ def components(edges: list[tuple[str,str]]) -> set[frozenset[str]]:
     return comp_set
 
 
-def components_d(
-    edges: list[tuple[str,str]],
-    vertices: Iterable[str] = (),
-) -> set[frozenset[str]]:
+def components_d[T: Hashable](
+    edges: list[tuple[T,T]], vertices: Iterable[T] = (),
+) -> set[frozenset[T]]:
     """
     Identify the connected components from an edge list.
 
@@ -211,22 +221,30 @@ def components_d(
     return _setofsets(components_dict(edges, vertices))
 
 
-def _setofsets(set_dict: dict[object,Iterable]) -> set:
+def _setofsets[T: Hashable](
+    set_dict: dict[object,Iterable[T]],
+) -> set[frozenset[T]]:
+    """Make a set of frozensets (components_d must assure preconditions)."""
     vals = set()
     for val in distinct(set_dict.values(), key=id):
         vals.add(frozenset(val))
     return vals
 
 
-def _setofsets_alt(set_dict: dict[object,Iterable]) -> set:
+def _setofsets_alt[T: Hashable](
+    set_dict: dict[object,Iterable[T]],
+) -> set[frozenset[T]]:
+    """Make a set of frozensets (like _setofsets, same preconditions)."""
     list_of_sets = distinct(set_dict.values(), key=id)
     return set(map(frozenset, list_of_sets))
 
 
-def components_dict(
-    edges: list[tuple[str,str]],
-    vertices: Iterable[str] = (),
-) -> dict[str,list[str]]:
+# TODO: Make a third version of _setofsets that uses a comprehension.
+
+
+def components_dict[T: Hashable](
+    edges: list[tuple[T,T]], vertices: Iterable[T] = (),
+) -> dict[T,list[T]]:
     """
     Identify the connected components from an edge list.
 
@@ -264,10 +282,9 @@ def components_dict(
     return comp_dict
 
 
-def components_dict_alt(
-    edges: list[tuple[str,str]],
-    vertices: Iterable[str] = (),
-) -> dict[str,list[str]]:
+def components_dict_alt[T: Hashable](
+    edges: list[tuple[T,T]], vertices: Iterable[T] = (),
+) -> dict[T,list[T]]:
     """
     Identify the connected components from an edge list.
 
@@ -305,10 +322,9 @@ def components_dict_alt(
 
 
 # FIXME: Actually implement classic quick-find.
-def components_dict_alt2(
-    edges: list[tuple[str,str]],
-    vertices: Iterable[str] = (),
-) -> dict[str,list[str]]:
+def components_dict_alt2[T: Hashable](
+    edges: list[tuple[T,T]], vertices: Iterable[T] = (),
+) -> dict[T,list[T]]:
     """
     Identify the connected components from an edge list.
 
@@ -341,10 +357,9 @@ def components_dict_alt2(
     return comp_dict
 
 
-def components_dfs(
-    edges: list[tuple[str,str]],
-    vertices: Iterable[str] = (),
-) -> set[frozenset[str]]:
+def components_dfs[T: Hashable](
+    edges: list[tuple[T,T]], vertices: Iterable[T] = (),
+) -> set[frozenset[T]]:
     """
     Identify the connected components from an edge list.
 
@@ -378,6 +393,7 @@ def components_dfs(
     return comp_set
 
 
+# TODO: Modify this for arbitrary recursion limits, and to use a comprehension.
 def devious() -> list[tuple[str,str]]:
     """
     Create a list of edges that defeats components_dfs.
@@ -395,10 +411,9 @@ def devious() -> list[tuple[str,str]]:
 
 
 # FIXME: Finish implementing this.
-def components_dfs_iter(
-    edges: list[tuple[str,str]],
-    vertices: Iterable[str] = (),
-) -> set[frozenset[str]]:
+def components_dfs_iter[T: Hashable](
+    edges: list[tuple[T,T]], vertices: Iterable[T] = (),
+) -> set[frozenset[T]]:
     """
     Identify the connected components from an edge list.
 

--- a/protocols.py
+++ b/protocols.py
@@ -1,16 +1,16 @@
 """Custom protocols for use in static type annotations."""
 
 from collections.abc import Hashable
-from typing import Protocol, Self
+from typing import Protocol
 
 
-class Sortable(Protocol):
+class SupportsLessThan[T](Protocol):
 
     __slots__ = ()
 
-    def __lt__(self, other: Self) -> bool: ...
+    def __lt__(self, other: T) -> bool: ...
 
 
-class HashableSortable(Hashable, Sortable, Protocol):
+class HashableSortable[T](Hashable, SupportsLessThan[T], Protocol):
 
     __slots__ = ()

--- a/protocols.py
+++ b/protocols.py
@@ -1,0 +1,16 @@
+"""Custom protocols for use in static type annotations."""
+
+from collections.abc import Hashable
+from typing import Protocol, Self
+
+
+class Sortable(Protocol):
+
+    __slots__ = ()
+
+    def __lt__(self, other: Self) -> bool: ...
+
+
+class HashableSortable(Hashable, Sortable, Protocol):
+
+    __slots__ = ()

--- a/protocols.py
+++ b/protocols.py
@@ -1,16 +1,16 @@
 """Custom protocols for use in static type annotations."""
 
 from collections.abc import Hashable
-from typing import Protocol
+from typing import Any, Protocol
 
 
-class SupportsLessThan[T](Protocol):
+class SupportsLessThan(Protocol):
 
     __slots__ = ()
 
-    def __lt__(self, other: T) -> bool: ...
+    def __lt__(self, other: Any) -> bool: ...
 
 
-class HashableSortable[T](Hashable, SupportsLessThan[T], Protocol):
+class HashableSortable(Hashable, SupportsLessThan, Protocol):
 
     __slots__ = ()

--- a/protocols.py
+++ b/protocols.py
@@ -1,10 +1,13 @@
 """Custom protocols for use in static type annotations."""
 
+__all__ = ['SupportsLessThan', 'HashableSortable']
+
 from collections.abc import Hashable
 from typing import Any, Protocol
 
 
 class SupportsLessThan(Protocol):
+    """Protocol representing types that define support for a ``<`` operator."""
 
     __slots__ = ()
 
@@ -12,5 +15,6 @@ class SupportsLessThan(Protocol):
 
 
 class HashableSortable(Hashable, SupportsLessThan, Protocol):
+    """Protocol representing types that define support for ``<`` and ``hash``."""
 
     __slots__ = ()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 doctestfn
 graphviz
 ipykernel
+pyright
 pytest
 ruff

--- a/util.py
+++ b/util.py
@@ -1,6 +1,6 @@
 """Utility functions used throughout the project."""
 
 
-def identity_function(arg):
+def identity_function[T](arg: T) -> T:
     """Return the argument unchanged."""
     return arg


### PR DESCRIPTION
This makes the type annotations accept an arbitrary hashable type for vertices, tracking that type through any inferences made by type checkers, thereby allowing any reasonable vertex type for these algorithms to be used, while preserving most of the precision we had with `str`, and preserving full type information in all inferences. The new [PEP 695](https://peps.python.org/pep-0695/) syntax for type parameters is used. This also adds the `pyright` type checker as a dependency. `pyright` is a strict type checker, and one of the most popular static type checkers for Python. The most popular static type checker for Python, `mypy`, which is also a strict type checker, cannot be used for it at this time because it does not yet support the PEP 695 syntax.

It is only "most of the precision" for two reasons. First, Python does not allow a type annotation to be constrained by a type based on a type annotation. This prevents the use of [CRTP](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern) to precisely express the ability to compare instances of a type to other instances of the same type, *but not necessarily to other objects*, as we would do in C# with:

```csharp
class Widget : IComparable<Widget> { /* ... */ }
```

Second, there is a hole in the type system itself, or, rather, the type system is designed in a way that accepts certain trade-offs most type systems reject. Python's `Hashable` type does not abide by the Liskov substitution principle, nor even by the usual expectation of transitivity in the subtype relation. This is the case both in the static type system and in the dynamic, i.e. actual, type system. Unlike most operations, the ability to call `hash` on something is an operation that is supported until a feature is implemented that removes it by customizing equality comparison without customizing hashing. In practice this happens when mutability is introduced. Python's abstract `Hashable` class is thus ill-behaved:

```text
>>> from collections.abc import Hashable
>>> issubclass(object, Hashable)
True
>>> issubclass(list, object)
True
>>> issubclass(list, Hashable)
False
```

I had originally hoped to do this PR without introducing any protocol definitions, since protocols are a special case of classes and the materials in this repository do not yet cover classes. Unfortunately that does not appear feasible. However, the details of the definitions can be ignored for now, and/or we could cover classes earlier than we might have otherwise.

One aspect of the change is worth pointing out specifically. To aid in reviewing it, I begin with a refresher on some aspects of generic variance, which might itself, in revised form, be suitable for inclusion as documentation here in `hiss`, in `palgoviz`, or elsewhere.

### The cat shelter problem

A [cat shelter](https://en.wikipedia.org/wiki/Covariance_and_contravariance_(computer_science)) seems like it would be an animal shelter, since every possible *value* of a cat shelter is also the value of an animal shelter. But it is not, because not every *operation* on animal shelters is an operation on cat shelters: an animal shelter supports dog insertion, while a cat shelter does not. Using a more constrained interface solves the problem: an animal shelter is an animal taker and an animal giver, a cat shelter is a cat taker and a cat giver, an animal taker is a cat taker, and a cat giver is an animal giver. Therefore:

| Shelter type | Animal taker | Cat taker | Animal giver | Cat giver |
|--------------|--------------|-----------|--------------|-----------|
| Animal shelter | Yes | Yes | Yes | No |
| Cat shelter | No | Yes | Yes | Yes |

Of course, this only applies to static type checking. At runtime, you may be able to know the animal an animal shelter gives you is a cat.

Here's a super non-exhaustive table with some relevant examples of types. Note that by "mutable" and "immutable" here, I just mean what operations the type guarantees can be done on all its instances.

| Kind of collection | Concrete immutable | Concrete mutable | Abstract immutable | Abstract mutable |
|--------------------|--------------------|------------------|---------------------|------------------|
| sequences          | tuple              | list             | Sequence            | MutableSequence  |
| sets               | frozenset          | set              | Set                 | MutableSet       |
| mappings           | MappingProxy       | dict             | Mapping             | MutableMapping   |

Thus, as a simple Python example, with `Base` and `Derived` classes, neither `set[Base]` nor `set[Derived]` is a static subtype of the other. This is only for the static type system. In the dynamic, i.e., actual type system of Python, they are exactly the same type, `set`; generic type arguments become part of a function or class's metadata, but they are not reified in instances. The reason neither is a subtype of the other is that, even though every value of `set[Derived]` is a value of `set[Base]`, a `set[Base]` supports the operation of having an `OtherDerived` instance added to it. In contrast, `frozenset[Derived]` *is* a static subtype of `frozenset[Base]`; immutable collections *are* covariant in their type parameters.

This applies to abstract types, too: a `Set[T]` is covariant in `T`, while a `MutableSet[T]` is not. Somewhat confusingly, as the above table shows, in Python `Set` is really the abstract analogue of `frozenset`, not of `set`. Conveniently, and for the same reason a cat shelter is an animal giver, a `set[Derived]` (concrete, mutable) is a static subtype of a `Set[Base]` (abstract, immutable).

| Concrete type | Set[Base] | Set[Derived] | MutableSet[Base] | MutableSet[Derived] |
|---------------|-----------|--------------|------------------|---------------------|
| frozenset[Base] | Yes   | No           | No               | No                  |
| frozenset[Derived]| Yes | Yes          | No               | No                  |
| set[Base]     | Yes       | No           | Yes              | No                  |
| set[Derived]  | Yes       | Yes          | No               | Yes                 |

Thus, functions that do not change the state of the objects their arguments refer to are most widely usable when their parameters are annotated with abstract immutable types. (Of course, this does not apply to return types. For maximum usability, those should be as specific as possible, within what you are willing to promise as part of the function's public interface.)

### Our cat shelters

This kind of change should be made to `dicts.py` in a number of places, but I think that's best left as an exercise, so I've only done it in the one place that needs it in our current usage. `dicts.py` now imports the abstract `Mapping` class and uses it in one place (technically two places) where `dict` was used. This is in `_setofsets` and `_setofsets_alt`, where a parameter type of `dict[K, Iterable[T]]` would not accept an argument with a type like `dict[K, list[T]]`, even though `list[T]` is a subtype of `Iterable[T]`.

https://github.com/tfallon0/hiss/blob/573e2a2a2878b1739708549db6dfbd24fac7efc9/dicts.py#L219-L226

The issue is not related to `list` being mutable. Rather, is because the concrete `dict` type, like the abstract `MutableMapping` type but unlike the abstract `Mapping` type, is mutable. Because a function that receives a `dict[K, Iterable[T]]` could cause the `dict` to contain a new value of any kind of `Iterable[T]`, which would not have to be a list, a `dict[K, list[T]]` cannot be passed as a `dict[K, Iterable[T]]`. In contrast, a `dict[K, list[T]]` can be passed as a `Mapping[K, Iterable[T]]`, since `Mapping` does not support any operations that change the values held in the `Mapping` instance.