### PR TITLE
Fix up test_greetall.py for Windows

### DIFF
--- a/test_greetall.txt
+++ b/test_greetall.txt
@@ -3,14 +3,23 @@ Doctests for the greetall.py script
 
 >>> import os
 >>> import pathlib
+>>> import re
 >>> import subprocess
 
->>> def attempt(shell_command):
-...     proc = subprocess.run(shell_command, capture_output=True, shell=True)
+>>> def decode(data):
+...     decoded = data.decode('utf-8')
+...     return decoded.replace('\r\n', '\n') if os.name == 'nt' else decoded
+
+>>> def attempt(command):
+...     if os.name == 'nt':
+...         # Usually sys.executable is better than "python", but this matches
+...         # the logic of the hashbang. (Virtual environments support this.)
+...         command = re.sub(r'^[.]/', f'python ', command)
+...     proc = subprocess.run(command, capture_output=True, shell=True)
 ...     if proc.stdout:
-...         print('STDOUT:', proc.stdout.decode('utf-8'), sep='\n', end='')
+...         print('STDOUT:', decode(proc.stdout), sep='\n', end='')
 ...     if proc.stderr:
-...         print('STDERR:', proc.stderr.decode('utf-8'), sep='\n', end='')
+...         print('STDERR:', decode(proc.stderr), sep='\n', end='')
 ...     return proc.returncode
 
 With no arguments, it reads from stdin and writes to stdout:


### PR DESCRIPTION
This fixes the incompatibilities with Windows in `test_greetall.txt`. Those tests now pass on Windows. This might be done in a better way in the future but I think this is an improvement.