### PR TITLE
Suppress reportFunctionMemberAccess

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,3 @@
+{
+    "reportFunctionMemberAccess": false
+}


### PR DESCRIPTION
This keeps `pyright` from warning about access to attributes we add to functions. Currently this is only done in `adders.py`, but soon it will likely be in more places, so the suppression is project-wide.